### PR TITLE
(Fix): Math Operators

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
+  <component name="CargoProjects">
+    <cargoProject FILE="$PROJECT_DIR$/Cargo.toml" />
+  </component>
   <component name="RustProjectSettings">
     <option name="toolchainHomeDirectory" value="$USER_HOME$/.cargo/bin" />
   </component>

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,9 +34,9 @@ fn main() {
         )
         .subcommand(clap::SubCommand::with_name("disassemble"))
         .subcommand(clap::SubCommand::with_name("run")
-            .arg(Arg::with_name("cli")
-                .long("cli")
-                .help("Launch in cli mode")
+            .arg(Arg::with_name("debug")
+                .long("debug")
+                .help("Continuously dump emulator state to the command line")
                 .takes_value(false)
                 .required(false)
             )
@@ -54,11 +54,9 @@ fn main() {
         Some("run") => {
             let mut system = System::new(buffer);
 
-            if matches.subcommand_matches("run").unwrap().is_present("cli") {
-                system.run_cli();
-            } else {
-                system.run_gui();
-            }
+            let dump_state = matches.subcommand_matches("run").unwrap()
+                .is_present("debug");
+            system.run(dump_state);
         }
         _ => {
             println!("ERROR: command invalid or not provided")


### PR DESCRIPTION
# Context
All the math related opcodes were misbehaving slightly. Adjusted them so they work more like expected.

Additionally removed `run_cli()`. Now with the `--debug` flag, we continuously dump state while running the GUI.

# Technical
Calls to wrapping functions, remove weird bitmath, and better bounds checking.

# TODO
 - [ ] CR
 - [ ] QA