### PR TITLE
(Chore): Add PR and Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,14 @@
+# Context
+The situation that drove you to create an issue in the first place.
+
+# Expected
+The expected behavior of the program. (Optional)
+
+# Actual
+The actual behavior of the program. (Optional)
+
+# Technical
+Any technical issues that need to be addressed before we can solve the issue. (Optional)
+
+# Tracking
+Any related issues or PRs for this issue. (Optional)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+# Context
+The situation that drove you to create a pull-request in the first place and what this actually does to solve it.
+
+# Technical
+A brief description of the technical changes you made to accomplish your goal.
+
+# TODO
+ - [ ] A checklist of things
+ - [ ] That need to happen
+ - [ ] Before this can be merged
+ - [ ] (Optional)


### PR DESCRIPTION
# Context
We don't have any templates for submitting PRs and raising issues! Noooooooo!

This helps us get organized and makes it easier for others to contribute. No brainer!

# Technical
Github looks in `.github` for folders named `ISSUE_TEMPLATE.md`, `PULL_REQUEST_TEMPLATE.md`, and `CONTRIBUTING.md`. The first two are pretty straight forward and add some starter text to every PR and issue dialog in the repo. `CONTRIBUTING.md` provides a message to all potential contributors on the main page of the repo, alongside the PR and issue dialogues.